### PR TITLE
CLOUD-2968 Move base layer of AMQ image from jboss-openjdk to rhel7

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -3,41 +3,56 @@ schema_version: 1
 name: "jboss-amq-6/amq63"
 description: "Red Hat JBoss AMQ 6.3 container image"
 version: "6.3.0"
-from: "jboss/openjdk18-rhel7:1.1-21"
+from: "rhel7:7-released"
 labels:
     - name: "com.redhat.component"
       value: "jboss-amq-6-amq63-container"
     - name: "org.jboss.product"
       value: "amq"
     - name: "org.jboss.product.version"
-      value: "6.3.0.redhat-347"
+      value: "6.3.0.redhat-356"
     - name: "org.jboss.product.amq.version"
-      value: "6.3.0.redhat-347"
+      value: "6.3.0.redhat-356"
 envs:
     - name: "JBOSS_PRODUCT"
       value: "AMQ"
     - name: "JBOSS_AMQ_VERSION"
-      value: "6.3.0.redhat-347"
+      value: "6.3.0.redhat-356"
     - name: "PRODUCT_VERSION"
-      value: "6.3.0.redhat-347"
+      value: "6.3.0.redhat-356"
     - name: "AMQ_HOME"
       value: "/opt/amq"
 modules:
       repositories:
           - path: modules
+          - name: cct_module
+            git:
+              url: https://github.com/jboss-openshift/cct_module.git
+              ref: master
       install:
+          - name: jboss.container.openjdk.jdk
+            version: "8"
           - name: amq-install
           - name: amq-chown
 artifacts:
-    - path: jboss-a-mq-6.3.0.redhat-347.zip
-      description: "Artifact is available on Customer Portal: https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=59151&product=jboss.amq.broker&version=6.3.0&downloadType=securityPatches"
-      md5: d26ed42769c93d90ad8fbe9d0a217105
+    - name: jboss-a-mq-6.3.0.redhat-356.zip
+      description: "Artifact is available on Customer Portal: https://access.redhat.com/jbossnetwork/restricted/listSoftware.html?product=jboss.amq.broker&downloadType=securityPatches&version=6.3.0"
+      md5: 13e415397cc343e6707e270f957467ce
 run:
       user: 185
       cmd:
           - "/opt/amq/bin/activemq"
           - "console"
 osbs:
+      configuration:
+            container:
+                  compose:
+                      pulp_repos: true
       repository:
             name: containers/jboss-amq-6
             branch: jb-amq-6.3-rhel-7
+packages:
+      content_sets:
+            x86_64:
+                - rhel-7-server-rpms
+

--- a/modules/amq-install/install.sh
+++ b/modules/amq-install/install.sh
@@ -3,8 +3,8 @@
 set -e
 
 SOURCES_DIR=/tmp/artifacts/
-DISTRIBUTION_VERSION="jboss-a-mq-6.3.0.redhat-347"
-ACTIVEMQ_VERSION="apache-activemq-5.11.0.redhat-630347"
+DISTRIBUTION_VERSION="jboss-a-mq-6.3.0.redhat-356"
+ACTIVEMQ_VERSION="apache-activemq-5.11.0.redhat-630356"
 
 unzip -q "$SOURCES_DIR/${DISTRIBUTION_VERSION}.zip"
 


### PR DESCRIPTION
Update the amq63 base image to latest.
Also use content_set as perfered by cekit 2.2.x.

Signed-off-by: Howard Gao <howard.gao@gmail.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for other issues
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
